### PR TITLE
Change image handling view URL naming rule to include app_label prefix.

### DIFF
--- a/docs/source/about_demo.rst
+++ b/docs/source/about_demo.rst
@@ -24,13 +24,13 @@ you will see 3 class-based views handling image instances:
 - :class:`galleryfield.image_views.BuiltInImageCreateView` for uploading images,
   requires login.
   Following the :ref:`naming rule <image_handling_url_naming_rule>`, The URL name is
-  ``builtingalleryimage-upload``.
+  ``galleryfield-builtingalleryimage-upload``.
 - :class:`galleryfield.image_views.BuiltInImageListView` for fetching existing images,
   restricted to the owner of the images or superuser, with URL name
-  ``builtingalleryimage-fetch``.
+  ``galleryfield-builtingalleryimage-fetch``.
 - and :class:`galleryfield.image_views.BuiltInImageCropView` for server side cropping
   of uploaded images, restricted to the owner of the images or superuser, with URL
-  name ``builtingalleryimage-crop``.
+  name ``galleryfield-builtingalleryimage-crop``.
 
 
 Handling the gallery

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -117,12 +117,12 @@ Alternatively, we can also let the widget infer what URLs it should use for thos
 following a naming rules for those views in ``URL_CONF``.
 
 For a valid image model, the default URL names for the image handling views are the lower cased
-``model_name``, suffixed by ``-upload``, ``-fetch`` and ``-crop``,
+``app_label-model_name``, suffixed by ``-upload``, ``-fetch`` and ``-crop``,
 respectively.
 
 For example, if you have a ``target_model`` named ``my_app.MyImage``, then the default
-URL names for the image handling views are ``myimage-upload``, ``myimage-fetch`` and
-``myimage-crop``. In this way, you don't need to specify in the ``GalleryWidget``
+URL names for the image handling views are ``my_app-myimage-upload``, ``my_app-myimage-fetch`` and
+``my_app-myimage-crop``. In this way, you don't need to specify in the ``GalleryWidget``
 the param ``upload_url`` and ``fetch_url``, and no need to specify the ``crop_url_name``
 in each of the 3 class-based views.
 

--- a/docs/source/widget.rst
+++ b/docs/source/widget.rst
@@ -10,8 +10,8 @@ The ``GalleryWidget`` class
 
 .. note:: When a :class:`galleryfield.fields.GalleryField` instance is initialized
    with ``galleryfield.BuiltInGalleryImage``, the widget instance will
-   automatically use URL names ``builtingalleryimage-upload``
-   ``builtingalleryimage-fetch`` for :attr:`upload_url`, :attr:`fetch_url`,
+   automatically use URL names ``galleryfield-builtingalleryimage-upload``
+   ``galleryfield-builtingalleryimage-fetch`` for :attr:`upload_url`, :attr:`fetch_url`,
    respectively.
 
 The URL params can be assigned after the formfield is initialized. For example:
@@ -40,8 +40,8 @@ The validity of the URL params will be checked before rendering.
    ) is
    **NOT** initialized with ``galleryfield.BuiltInGalleryImage`` as the
    :attr:`target_model`, assigning built-in URL names (
-   i.e., ``builtingalleryimage-upload``, ``builtingalleryimage-fetch``)
-   in widget params, or set ``builtingalleryimage-crop`` for `crop_url_name` in
+   i.e., ``galleryfield-builtingalleryimage-upload``, ``galleryfield-builtingalleryimage-fetch``)
+   in widget params, or set ``galleryfield-builtingalleryimage-crop`` for `crop_url_name` in
    image handling views, :exc:`ImproperlyConfigured` will be raised
    when rendering. The reason is, those built-in views are handling
    built-in :class:`galleryfield.models.BuiltInGalleryImage` instances.

--- a/galleryfield/defaults.py
+++ b/galleryfield/defaults.py
@@ -18,9 +18,9 @@ JQUERY_FILE_UPLOAD_UI_DEFAULT_OPTIONS = {
 # {{{ DO NOT change this if you have deployed this app on you production server!
 # Or else it might cause unexpected result!
 
-DEFAULT_UPLOAD_URL_NAME = "builtingalleryimage-upload"
-DEFAULT_CROP_URL_NAME = "builtingalleryimage-crop"
-DEFAULT_FETCH_URL_NAME = "builtingalleryimage-fetch"
+DEFAULT_UPLOAD_URL_NAME = "galleryfield-builtingalleryimage-upload"
+DEFAULT_CROP_URL_NAME = "galleryfield-builtingalleryimage-crop"
+DEFAULT_FETCH_URL_NAME = "galleryfield-builtingalleryimage-fetch"
 
 DEFAULT_TARGET_IMAGE_MODEL = "galleryfield.BuiltInGalleryImage"
 DEFAULT_TARGET_IMAGE_FIELD_NAME = "image"

--- a/galleryfield/fields.py
+++ b/galleryfield/fields.py
@@ -243,26 +243,28 @@ class GalleryFormField(forms.JSONField):
         self._set_widget_fetch_url()
 
     @property
-    def _target_model_name(self):
-        return self._image_model.split(".")[-1]
+    def _target_app_model_name(self):
+        return "-".join(self._image_model.split(".")).lower()
 
     def _set_widget_upload_url(self):
         if self.widget.upload_url:
             return
 
         # Here we required a target_model should have a upload_url
-        # name in url_conf in the form of modelname-upload in lower case
+        # name in url_conf in the form of app_label_model_name-upload
+        # in lower case
         self.widget.upload_url = (
-                "%s-upload" % self._target_model_name.lower())
+                "%s-upload" % self._target_app_model_name.lower())
 
     def _set_widget_fetch_url(self):
         if self.widget.disable_fetch or self.widget.fetch_url:
             return
 
         # Here we required a target_model should have a fetch_url
-        # name in url_conf in the form of modelname-fetch in lower case
+        # name in url_conf in the form of app_label-model_name-fetch
+        # in lower case
         self.widget.fetch_url = (
-                "%s-fetch" % self._target_model_name.lower())
+                "%s-fetch" % self._target_app_model_name.lower())
 
     @property
     def max_number_of_images(self):

--- a/galleryfield/image_views.py
+++ b/galleryfield/image_views.py
@@ -97,7 +97,7 @@ class ImageCropView(BaseCropViewMixin, UpdateView):
 
 class BuiltInImageCreateView(ImageCreateView):
     target_model = "galleryfield.BuiltInGalleryImage"
-    crop_url_name = "builtingalleryimage-crop"  # This line can be commented
+    crop_url_name = "galleryfield-builtingalleryimage-crop"  # Can be omitted
     disable_server_side_crop = False
 
     def form_valid(self, form):
@@ -109,7 +109,7 @@ class BuiltInImageCreateView(ImageCreateView):
 
 class BuiltInImageListView(ImageListView):
     target_model = "galleryfield.BuiltInGalleryImage"
-    crop_url_name = "builtingalleryimage-crop"  # This line can be commented
+    crop_url_name = "galleryfield-builtingalleryimage-crop"  # Can be omitted
     disable_server_side_crop = False
 
     def get_queryset(self):
@@ -121,7 +121,7 @@ class BuiltInImageListView(ImageListView):
 
 class BuiltInImageCropView(ImageCropView):
     target_model = "galleryfield.BuiltInGalleryImage"
-    crop_url_name = "builtingalleryimage-crop"  # This line can be commented
+    crop_url_name = "galleryfield-builtingalleryimage-crop"  # Can be commented
     disable_server_side_crop = False
 
     def get_object(self, queryset=None):

--- a/galleryfield/mixins.py
+++ b/galleryfield/mixins.py
@@ -28,10 +28,9 @@ class BaseImageModelMixin:
     :attr:`target_model`: A valid target image model used by the view.
     :attr:`crop_url_name`: str, An URL name or an URL for handling server side
        cropping of uploaded images, if configured None, it will used the value
-       in the form of ``model_name-crop`` in lower case, where the modelname is
-       the second part of ``self.target_model``. For example, if
+       in the form of ``app_label-model_name-crop`` in lower case. For example, if
        ``self.target_model`` is ``my_app.MyImage``, then the `crop_url_name`
-       is auto-configured to ``myimage-crop``. You need to make sure you
+       is auto-configured to ``my_app-myimage-crop``. You need to make sure you
        had that URL name in your URL_CONF and related views exists.
 
     :attr:`disable_server_side_crop`: bool, determining whether server side crop
@@ -71,8 +70,8 @@ class BaseImageModelMixin:
         if self.disable_server_side_crop:
             return
         if self.crop_url_name is None:
-            model_name = self.target_model.split(".")[-1].lower()
-            self.crop_url_name = "%s-crop" % model_name
+            app_model_name = "-".join(self.target_model.split(".")).lower()
+            self.crop_url_name = "%s-crop" % app_model_name
         try:
             reverse(self.crop_url_name, kwargs={"pk": 1})
         except Exception as e:

--- a/galleryfield/urls.py
+++ b/galleryfield/urls.py
@@ -3,16 +3,16 @@ from django.urls import path
 
 from galleryfield import image_views
 
-# The default view names also follow the form of "model_name-upload".
+# The default view names also follow the form of "app_label-model_name-upload".
 
 urlpatterns = [
     path('upload/',
          login_required(image_views.BuiltInImageCreateView.as_view()),
-         name="builtingalleryimage-upload"),
+         name="galleryfield-builtingalleryimage-upload"),
     path('fetch/',
          login_required((image_views.BuiltInImageListView.as_view())),
-         name="builtingalleryimage-fetch"),
+         name="galleryfield-builtingalleryimage-fetch"),
     path('crop/<int:pk>',
          login_required(image_views.BuiltInImageCropView.as_view()),
-         name="builtingalleryimage-crop"),
+         name="galleryfield-builtingalleryimage-crop"),
 ]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -14,8 +14,8 @@ class GetUrlFromStrTest(SimpleTestCase):
 
     def test_valid_url_name(self):
         self.assertEqual(
-            get_url_from_str("builtingalleryimage-upload"),
-            reverse("builtingalleryimage-upload")
+            get_url_from_str("galleryfield-builtingalleryimage-upload"),
+            reverse("galleryfield-builtingalleryimage-upload")
         )
 
     def test_invalid_url_name(self):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -223,18 +223,18 @@ class GalleryWidgetTest(SimpleTestCase):
         field = GalleryFormField(target_model="tests.FakeValidImageModel")
 
         test_case = {
-            "builtingalleryimage-upload":
+            "galleryfield-builtingalleryimage-upload":
                 {"upload_url": "test_image_upload"},
-            "builtingalleryimage-crop":
+            "galleryfield-builtingalleryimage-crop":
                 {"crop_request_url": "test_image_crop"},
-            "builtingalleryimage-fetch":
+            "galleryfield-builtingalleryimage-fetch":
                 {"fetch_url": "test_images_fetch"}
         }
 
         default_urls = {
-            "upload_url": "builtingalleryimage-upload",
-            "crop_request_url": "builtingalleryimage-crop",
-            "fetch_url": "builtingalleryimage-fetch"
+            "upload_url": "galleryfield-builtingalleryimage-upload",
+            "crop_request_url": "galleryfield-builtingalleryimage-crop",
+            "fetch_url": "galleryfield-builtingalleryimage-fetch"
         }
 
         for default, kwargs in test_case.items():


### PR DESCRIPTION
This is IMPORTANT for avoid naming conficts of image models with same name in different apps.