### PR TITLE
Fix django-crispy-forms in tests and demos.

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,5 +1,5 @@
 django<=3.3
-django-crispy-forms
+django-crispy-forms<2
 sorl-thumbnail
 pillow
 

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -1,7 +1,7 @@
 django
 sorl-thumbnail
 pillow
-django-crispy-forms
+django-crispy-forms<2
 
 codecov
 factory_boy


### PR DESCRIPTION
Bootstrap templates were not longer included in django-cripsy-forms since version >=2.